### PR TITLE
determine category names once

### DIFF
--- a/bin/sbozyp
+++ b/bin/sbozyp
@@ -25,6 +25,8 @@ our %CONFIG = (
     #REPO_NAME => REPO_PRIMARY
 );
 
+our @all_categories;
+
  # 'unless caller' allows us to load this file from test code without executing main()
 unless (caller) { main(@ARGV) ; exit 0 }
 
@@ -66,6 +68,7 @@ sub main {
         i_am_root_or_die('need root to sync repo');
         sync_repo();
     }
+    @all_categories = all_categories();
     # run the command
     $cmd_main->(@argv);
 }
@@ -362,7 +365,7 @@ sub find_pkgname { # if $prgnam is a pkgname then just return it back
     $prgnam or return;
     return $prgnam if $prgnam =~ m,^[^/]+/[^/]+$, && -d "$CONFIG{REPO_ROOT}/$CONFIG{REPO_NAME}/$prgnam";
     my $pkgname;
-    for my $category (all_categories()) {
+    for my $category (@all_categories) {
         $pkgname = "$category/$prgnam" if -d "$CONFIG{REPO_ROOT}/$CONFIG{REPO_NAME}/$category/$prgnam";
     }
     return $pkgname;


### PR DESCRIPTION
Currently, system `find` is called every time `sbozyp` determines a package name. This makes queue calculation take considerably longer for the more complicated ones (try `sbozyp query -q pandoc`, for example).

Another approach would be to use `glob` in `find_pkgname()` and removing `all_categories()`, but I found that doing it this way was a shade faster.