### PR TITLE
add query -x flag to list installed packages not in the current repo

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.7.0  TBD
+
+   - Added -x query flag to print installed SBo packages
+     not in the current repo
+
 1.6.0  2026-03-11
 
    - Added -n flag to install and build commands to skip

--- a/bin/sbozyp
+++ b/bin/sbozyp
@@ -204,13 +204,14 @@ sub main_query {
         'r'      => \my $opt_readme,
         's'      => \my $opt_slackbuild,
         'u'      => \my $opt_listneedupdate,
-        'v'      => \my $opt_listneedupdateversion
+        'v'      => \my $opt_listneedupdateversion,
+        'x'      => \my $opt_listpkgsnotinrepo
     );
     if ($opt_help) { print command_help_msg('query'); return }
     if (@_ > 1) { die command_usage('query') }
-    my $num_opts_set = 0; for ($opt_listinstalled,$opt_printpackagedir,$opt_printrepodir,$opt_slackdesc,$opt_info,$opt_pkgsnodependents,$opt_recdependents,$opt_directdependents,$opt_pkginstalled,$opt_printqueue,$opt_readme,$opt_slackbuild,$opt_listneedupdate,$opt_listneedupdateversion) { $num_opts_set++ if defined }
-    if    ($num_opts_set != 1)  { sbozyp_die("must set exactly 1 query option but $num_opts_set were set") }
-    my $opt = $opt_listinstalled ? '-a' : $opt_printpackagedir ? '-b' : $opt_printrepodir ? '-c' : $opt_slackdesc ? '-d' : $opt_info ? '-i' : $opt_pkgsnodependents ? '-m' : $opt_recdependents ? '-n' : $opt_directdependents ? '-o' : $opt_pkginstalled ? '-p' : $opt_printqueue ? '-q' : $opt_readme ? '-r' : $opt_slackbuild ? '-s' : $opt_listneedupdate ? '-u' : $opt_listneedupdateversion ? '-v' : die;
+    my $num_opts_set = 0; for ($opt_listinstalled,$opt_printpackagedir,$opt_printrepodir,$opt_slackdesc,$opt_info,$opt_pkgsnodependents,$opt_recdependents,$opt_directdependents,$opt_pkginstalled,$opt_printqueue,$opt_readme,$opt_slackbuild,$opt_listneedupdate,$opt_listneedupdateversion,$opt_listpkgsnotinrepo) { $num_opts_set++ if defined }
+    if ($num_opts_set != 1) { sbozyp_die("must set exactly 1 query option but $num_opts_set were set") }
+    my $opt = $opt_listinstalled ? '-a' : $opt_printpackagedir ? '-b' : $opt_printrepodir ? '-c' : $opt_slackdesc ? '-d' : $opt_info ? '-i' : $opt_pkgsnodependents ? '-m' : $opt_recdependents ? '-n' : $opt_directdependents ? '-o' : $opt_pkginstalled ? '-p' : $opt_printqueue ? '-q' : $opt_readme ? '-r' : $opt_slackbuild ? '-s' : $opt_listneedupdate ? '-u' : $opt_listneedupdateversion ? '-v' : $opt_listpkgsnotinrepo ? '-x' : die;
     my $pkg; if ($opt_printpackagedir || $opt_slackdesc || $opt_info || $opt_recdependents || $opt_directdependents || $opt_pkginstalled || $opt_printqueue || $opt_readme || $opt_slackbuild) {
         @_ == 1 or sbozyp_die("query option '$opt' requires single PKGNAME argument");
         $pkg = pkg($_[0]);
@@ -263,6 +264,8 @@ sub main_query {
                 print "$pkgname $installed_version -> $available_version\n";
             }
         }
+    } elsif ($opt_listpkgsnotinrepo) {
+        print "$_\n" for sbo_pkgs_not_in_repo();
     }
 }
 
@@ -426,8 +429,7 @@ sub pkg_matches_blacklist {
 sub parse_slackware_pkgname {
     my ($slackware_pkgname) = @_;
     my ($prgnam, $version) = $slackware_pkgname =~ /^([\w.+-]+)-([^-]*)-[^-]*-\d+_SBo$/;
-    my $pkgname = prgnam_to_pkgname($prgnam);
-    return ($pkgname => $version);
+    return ($prgnam => $version);
 }
 
 sub installed_sbo_pkgs {
@@ -435,12 +437,23 @@ sub installed_sbo_pkgs {
     my %installed_sbo_pkgs;
     if (-d "$root/var/lib/pkgtools/packages") {
         %installed_sbo_pkgs = map {
-            my ($pkgname, $version) = parse_slackware_pkgname(basename($_));
+            my ($prgnam, $version) = parse_slackware_pkgname(basename($_));
             # If $pkgname is undef then the current repo doesnt have the package. We only manage packages in the current repo.
+            my $pkgname = prgnam_to_pkgname($prgnam);
             defined $pkgname ? ($pkgname, $version) : ();
         } grep /_SBo$/, sbozyp_readdir("$root/var/lib/pkgtools/packages");
     }
     return %installed_sbo_pkgs;
+}
+
+sub sbo_pkgs_not_in_repo {
+    state @prgnams = do {
+        my $root = $ENV{ROOT} // '/';
+        sort grep { !prgnam_to_pkgname($_) } map {
+            my ($prgnam) = parse_slackware_pkgname(basename($_));
+        } grep /_SBo$/, sbozyp_readdir("$root/var/lib/pkgtools/packages");
+    };
+    return @prgnams;
 }
 
 sub all_pkg_categories {
@@ -1213,7 +1226,7 @@ Examples:
 
 =head2 QUERY
 
- Usage: sbozyp <query|qr> [-h] [-a] [-b] [-c] [-d] [-i] [-m] [-n] [-o] [-p] [-q] [-r] [-s] [-u] [-v] PKGNAME?
+ Usage: sbozyp <query|qr> [-h] [-a] [-b] [-c] [-d] [-i] [-m] [-n] [-o] [-p] [-q] [-r] [-s] [-u] [-v] [-x] PKGNAME?
 
 Query for package related information.
 
@@ -1236,6 +1249,7 @@ Options are:
  -s            Print PKGNAME's .SlackBuild file
  -u            Print all packages that have updates available
  -v            Like -u, but also print the version information
+ -x            Print all installed SBo packages not in the current repo
 
 Examples:
 
@@ -1244,6 +1258,7 @@ Examples:
  sbozyp qr -m
  sbozyp -S qr -u
  cd $(sbozyp qr -b password-store)
+ removepkg $(sbozyp qr -x) # remove packages not in current repo
  sbozyp -S -R $REPO qr -r password-store
 
 =head2 SEARCH

--- a/package/sbozyp.bash
+++ b/package/sbozyp.bash
@@ -101,7 +101,7 @@ _sbozyp_complete() {
             fi
             ;;
         query|qr)
-            local opts="--help -a -b -c -d -i -m -n -o -p -q -r -s -u -v"
+            local opts="--help -a -b -c -d -i -m -n -o -p -q -r -s -u -v -x"
             if [[ $cur == qr ]]; then
                 COMPREPLY=( "query" )
             elif [[ $cur == -* ]]; then

--- a/package/sbozyp.zsh
+++ b/package/sbozyp.zsh
@@ -103,7 +103,7 @@ _sbozyp_complete() {
             fi
             ;;
         query|qr)
-            local opts="--help -a -b -c -d -i -m -n -o -p -q -r -s -u -v"
+            local opts="--help -a -b -c -d -i -m -n -o -p -q -r -s -u -v -x"
             if [[ $cur == qr ]]; then
                 compadd -U -- "query"
             elif [[ $cur == -* ]]; then

--- a/t/sbozyp.t
+++ b/t/sbozyp.t
@@ -872,42 +872,42 @@ subtest 'pkgs_confirm_with_user()' => sub {
 
 subtest 'parse_slackware_pkgname()' => sub {
     is([Sbozyp::parse_slackware_pkgname('acpica-20220331-x86_64-1_SBo')],
-       ['development/acpica', '20220331'],
+       ['acpica', '20220331'],
        'parses non-hyphened pkgname'
     );
 
     is([Sbozyp::parse_slackware_pkgname('password-store-1.7.4-noarch-1_SBo')],
-       ['system/password-store', '1.7.4'],
+       ['password-store', '1.7.4'],
        'parses single-hyphened pkgname'
     );
 
     is([Sbozyp::parse_slackware_pkgname('perl-File-Copy-Recursive-0.2.3-x86_64-1_SBo')],
-       ['perl/perl-File-Copy-Recursive', '0.2.3'],
+       ['perl-File-Copy-Recursive', '0.2.3'],
        'parses many-hyphened pkgname'
     );
 
     is([Sbozyp::parse_slackware_pkgname('functools32-3.2.3_1-x86_64-1_SBo')],
-       ['python/functools32', '3.2.3_1'],
+       ['functools32', '3.2.3_1'],
        'parses pkgname containing numbers'
     );
 
     is([Sbozyp::parse_slackware_pkgname('python-e_dbus-12.2-x86_64-1_SBo')],
-       ['libraries/python-e_dbus', '12.2'],
+       ['python-e_dbus', '12.2'],
        'parses prgnam containing underscore'
     );
 
     is([Sbozyp::parse_slackware_pkgname('virtualbox-kernel-6.1.40_6.1.12-x86_64-1_SBo')],
-       ['system/virtualbox-kernel', '6.1.40_6.1.12'],
+       ['virtualbox-kernel', '6.1.40_6.1.12'],
        'parses version containing underscore'
     );
 
     is([Sbozyp::parse_slackware_pkgname('acpica-20220331-x86_64-1000_SBo')],
-       ['development/acpica', '20220331'],
+       ['acpica', '20220331'],
        'parses pkgname with multi-digit revision'
     );
 
     is([Sbozyp::parse_slackware_pkgname('sbozyp-special_1.Chars+pkg-2.0-x86_64-1_SBo')],
-       ['misc/sbozyp-special_1.Chars+pkg', '2.0'],
+       ['sbozyp-special_1.Chars+pkg', '2.0'],
        'parses prgnam containing dot, plus, uppercase, digit, underscore'
     );
 
@@ -1101,6 +1101,47 @@ subtest 'installed_sbo_pkgs()' => sub {
             unlink $slackware_pkg or die;
         }
     }
+    remove_tree("$TEST_DIR/tmp_root") or die;
+};
+
+subtest 'sbo_pkgs_not_in_repo()' => sub {
+    local $ENV{ROOT} = "$TEST_DIR/tmp_root";
+    make_path("$ENV{ROOT}/var/lib/pkgtools/packages") or die;
+
+    my $touch = sub { open my $fh, '>', "$ENV{ROOT}/var/lib/pkgtools/packages/$_[0]" or die };
+
+    # Installed _SBo packages that ARE in the repo — should NOT appear in results
+    $touch->('sbozyp-basic-1.0-noarch-1_SBo');
+    $touch->('sbozyp-nested-dir-1.0-x86_64-1_SBo');
+    $touch->('sbozyp-readme-extra-deps-1.0-noarch-1_SBo');
+
+    # Installed _SBo packages NOT in the repo — should appear in results
+    $touch->('foobar-2.0-x86_64-1_SBo');
+    $touch->('zzz-old-pkg-3.5-i686-1_SBo');
+    $touch->('aaa-first-1.0-noarch-1_SBo');
+
+    # Non-_SBo packages — should be ignored
+    $touch->('notasbo-1.0-noarch-1_alien');
+    $touch->('regularpkg-1.0-noarch-1');
+
+    my @result = Sbozyp::sbo_pkgs_not_in_repo();
+
+    is(\@result, [qw(aaa-first foobar zzz-old-pkg)],
+       'returns sorted prgnams of installed _SBo packages not in the current repo, excluding in-repo and non-_SBo packages'
+      );
+
+    ok(!grep({ $_ eq 'sbozyp-basic' } @result), 'excludes packages that are in the repo');
+    ok(!grep({ $_ eq 'notasbo' } @result), 'ignores packages without the _SBo tag');
+    ok(!grep({ $_ eq 'regularpkg' } @result), 'ignores packages without any tag');
+
+    is($result[0], 'aaa-first', 'results are sorted alphabetically (first element)');
+    is($result[-1], 'zzz-old-pkg', 'results are sorted alphabetically (last element)');
+
+    # state caching: second call returns same results even after modifying the directory
+    $touch->('another-missing-9.0-noarch-1_SBo');
+    my @cached_result = Sbozyp::sbo_pkgs_not_in_repo();
+    is(\@cached_result, \@result, 'subsequent calls return cached results (state variable)');
+
     remove_tree("$TEST_DIR/tmp_root") or die;
 };
 
@@ -1721,6 +1762,10 @@ subtest 'main_query()' => sub {
 
     ($stdout) = capture { Sbozyp::main_query('-q', 'sbozyp-recursive-dep-A') };
     like($stdout, qr|^misc/sbozyp-recursive-dep-F\nmisc/sbozyp-recursive-dep-E\nmisc/sbozyp-recursive-dep-C\nmisc/sbozyp-recursive-dep-D\nmisc/sbozyp-recursive-dep-B\nmisc/sbozyp-recursive-dep-A\n$|s, 'prints packages dependencies (in order and recursively) if given -q option');
+
+    ($stdout) = capture { Sbozyp::main_query('-x') };
+    is($stdout, "aaa-first\nfoobar\nzzz-old-pkg\n", '-x prints installed _SBo packages not in the current repo');
+    like(dies { Sbozyp::main_query('-x', 'sbozyp-basic') }, qr/^sbozyp: error: query option '-x' does not take PKGNAME argument$/, 'dies with useful error if given PKGNAME arg with -x');
 
     if ($> == 0) { # need to be root to install a package
         local $ENV{ROOT} = "$TEST_DIR/tmp_root"; # were gonna install some packages


### PR DESCRIPTION
This PR solves issue #26 

To make sbozyp understand a notion of "dropped" packages, in a way that it can handle them automatically, turns out to be quite difficult. The solution I went with was to add a new `query` command flag called `-x`, that prints all installed SBo packages not in the current repo. This gives users a way remove them easily by running `removepkg $(sbozyp qr -x)`. I added an example of this to the docs.